### PR TITLE
🧹 [chore] Remove unused CSS class 'share-heading'

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -642,12 +642,6 @@ body::before {
   margin: 0 auto;
 }
 
-.footer .share-heading {
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-  margin-bottom: 12px;
-}
-
 .social-links {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
🎯 **What:** Removed unused CSS class `.footer .share-heading` from `styles.css`.
💡 **Why:** Dead code clutters the stylesheet, increasing cognitive load for developers and unnecessarily inflating file size. Removing unused code improves codebase maintainability and readability.
✅ **Verification:** Verified that the class `.share-heading` does not exist in the HTML structure (`index.html`). Ran Python's `html.parser` script to ensure HTML was completely valid. Checked with Git diff that only the target rule was removed and no adjacent rules were accidentally modified.
✨ **Result:** A cleaner `styles.css` file without dead code blocks, ready for production use.

---
*PR created automatically by Jules for task [3673341551362783788](https://jules.google.com/task/3673341551362783788) started by @Geovannisz*